### PR TITLE
Fixed exception thrown in Exception.toString()

### DIFF
--- a/src/Error/Exception.ts
+++ b/src/Error/Exception.ts
@@ -1,10 +1,11 @@
 ﻿module TypeMoq.Error {
     export class Exception implements Error {
         constructor(public name?: string, public message?: string) {
+            this.name = name;
         }
 
         toString(): string {
-            return name;
+            return this.name;
         }
     }
 }


### PR DESCRIPTION
Exception was thrown on failed expectation verification.