### PR TITLE
Fix ExtractProxyCall from mutating the context

### DIFF
--- a/src/InterceptorStrategies.ts
+++ b/src/InterceptorStrategies.ts
@@ -13,7 +13,8 @@ module TypeMoq {
     export class ExtractProxyCall<T> implements IInterceptStrategy<T> {
 
         handleIntercept(invocation: proxy.ICallContext, ctx: InterceptorContext<T>, localCtx: CurrentInterceptContext<T>): InterceptionAction {
-            var reversedOrderedCalls = ctx.orderedCalls().reverse();
+            var reversedOrderedCalls = ctx.orderedCalls().slice().reverse();
+
             localCtx.call = _.find(reversedOrderedCalls, c => {
                 return c.matches(invocation);
             });

--- a/test/spec/Mock.test.ts
+++ b/test/spec/Mock.test.ts
@@ -259,6 +259,19 @@ module TypeMoq.Tests {
                 expect(mock.object.foo).to.eq("At vero eos et accusamus et iusto odio dignissimos ducimus");
             });
 
+            it("should prefer newest setup when multiple methods are setup", () => {
+                var mock = Mock.ofType(Doer);
+
+                mock.setup(x => x.doNumber(It.isAnyNumber())).returns(() => 999);
+                mock.setup(x => x.doString(It.isAnyString())).returns(() => "123");
+
+                mock.setup(x => x.doString(It.isAnyString())).returns(() => "456");
+
+                var user = new DoerUser(mock.object);
+
+                expect(user.execute("abc", 123)).to.eq("456");
+            });
+
         });
 
         describe(".callback", () => {

--- a/test/spec/samples.ts
+++ b/test/spec/samples.ts
@@ -68,6 +68,19 @@ module TypeMoq.Tests {
         doBar(b?: Bar): Bar { return b; }
     }
 
+    export class DoerUser {
+        private doer: IDo;
+
+        constructor(doer: IDo) {
+            this.doer = doer;
+        }
+
+        execute(s: string, n: number): string {
+            this.doer.doNumber(n);
+            return this.doer.doString(s);
+        }
+    }
+
     export class FooService implements IFooService { }
     export interface IFooService { }
 


### PR DESCRIPTION
Fixes bug #5 as the invoking the ExtractProxyCall interceptor causes the
context to be mutated, which causes older setups to be preferred over
newer setups for every odd number of invocations on the same mock
context.