### PR TITLE
make dynamic mock callable

### DIFF
--- a/src/Proxy/ProxyES6.ts
+++ b/src/Proxy/ProxyES6.ts
@@ -12,7 +12,7 @@ export class ProxyES6<T> implements IProxy {
     readonly ___id = Consts.IPROXY_ID_VALUE;
 
     private constructor(interceptor: ICallInterceptor) {
-        
+
         let handler: ProxyHandler<T> = {
             apply: (target: T, thisArg: any, argArray?: any): any => {
 
@@ -27,10 +27,10 @@ export class ProxyES6<T> implements IProxy {
 
                 let propValue = (<any>target)[p];
                 let method = new PropertyInfo(target, <string>p, { value: true });
-                let valueInvocation = new ValueGetterInvocation(method, propValue);          
+                let valueInvocation = new ValueGetterInvocation(method, propValue);
                 interceptor.intercept(valueInvocation);
 
-                if (valueInvocation.returnValue && 
+                if (valueInvocation.returnValue &&
                     valueInvocation.property.desc && valueInvocation.property.desc.value) // value getter invocation at execution time
                     return valueInvocation.returnValue;
                 else
@@ -54,8 +54,8 @@ export class ProxyES6<T> implements IProxy {
                 return true;
             }
         };
-
-        let p = <ProxyES6<T>>new Proxy({}, handler);
+        function doNothing() {}
+        let p = <ProxyES6<T>>new Proxy(doNothing as any, handler);
 
         return p;
     }


### PR DESCRIPTION
Hi.

I use your library in my side project and really like it so far. Great solution for mocking typed code, especially with es6 proxy mocks!
That being said I encountered small issues, so here is my proposition of fix:

Calling proxied function (dynamic mock implemented with es6 proxy to be precise) is impossible right now.
Code 
```javascript
const fnMock = Mock.ofType<Function>();
fnMock
   .setup(fn => fn())
   /* ... */
```
will thow error `fn is not a function`.

It turns out es6 proxy will be callable only if proxied object is callable.
It means that in your library line:
```javascript
new Proxy({}, handler);
```
should be changed to
```
new Proxy(() => {}, handler);
```
Note that this is more general, since every function is an object - all dynamic object mocks will still work, and error about fn not being function will disappear.

Thanks in advance and have a great day!