### PR TITLE
Removed @types/node from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.37",
-    "@types/node": "^6.0.45",
     "lodash": "^4.16.4",
     "postinstall-build": "^2.1.3"
   },


### PR DESCRIPTION
This is related to issue #41. I tried simply removing the @types/node dependency and that did not seem to have any side-effects. I ran the gulp script and all tests but one passed. The one that did not was hung pending, but it also hangs when @types/node is installed. I am on a Mac, so the IE tests did not run, but I can't see how they would be affected by a node dependency.