### PR TITLE
Allow to verify a mock method call never occurred in Strict mode.

### DIFF
--- a/src/StaticMock.ts
+++ b/src/StaticMock.ts
@@ -61,6 +61,7 @@ export class StaticMock<T> extends MockBase<T> {
 
     verify<TResult>(expression: all.IFunc2<T, TResult>, times: all.Times): void {
         const call = MethodCall.ofStaticMock(this, expression);
+        call.verifiable(times);
         this._interceptor.addExpectedCall(call);
         try {
             this._interceptor.verifyCallCount(call, times);

--- a/test/spec/GlobalMock.test.ts
+++ b/test/spec/GlobalMock.test.ts
@@ -9,10 +9,7 @@ const GlobalScope = TypeMoq.GlobalScope;
 const It = TypeMoq.It;
 const Times = TypeMoq.Times;
 
-import * as chai from "chai";
-
-const assert = chai.assert;
-const expect = chai.expect;
+import { expect } from "chai";
 
 let container: any;
 if (Utils.isNodeJS())

--- a/test/spec/Mock.test.ts
+++ b/test/spec/Mock.test.ts
@@ -392,6 +392,14 @@ describe("Mock", () => {
             expect(() => mock.object.doNumber(999)).to.throw(Error);
         });
 
+        it("should support verify never when behavior is strict", () => {
+
+            const mock = Mock.ofType(TypeMoqTests.Doer, MockBehavior.Strict);
+
+            mock.verify(m => m.doVoid(), Times.never());
+            mock.verifyAll();
+        });
+
         describe("dynamic mock", () => {
 
             it("should return default value when no setup found and behavior is loose", () => {

--- a/test/spec/Mock.test.ts
+++ b/test/spec/Mock.test.ts
@@ -4,7 +4,6 @@ import * as TypeMoq from "typemoq";
 import * as _ from "lodash";
 
 import { TypeMoqTests } from "./fixtures";
-import { Utils } from "./Utils";
 
 const Mock = TypeMoq.Mock;
 const MockBehavior = TypeMoq.MockBehavior;
@@ -13,10 +12,7 @@ const Times = TypeMoq.Times;
 const ExpectedCallType = TypeMoq.ExpectedCallType;
 const MockException = TypeMoq.MockException;
 
-import * as chai from "chai";
-
-const assert = chai.assert;
-const expect = chai.expect;
+import { expect } from "chai";
 
 const hasProxyES6 = (typeof Proxy != "undefined");
 const noProxyES6Msg = "global 'Proxy' object not available";


### PR DESCRIPTION
When in strict mode verifying that a method call never occured was
adding an expected call without passing the expected times. The default
times being once, when verifyAll is called on the mock the tests failed
with Configured setups expected once but was never invoked.