### PR TITLE
Adding optional ExpectedCallType to verifiable interface.

### DIFF
--- a/src/Api/IVerifies.ts
+++ b/src/Api/IVerifies.ts
@@ -1,5 +1,6 @@
 ﻿import { Times } from "./Times";
+import { ExpectedCallType } from "./ExpectedCallType";
 
 export interface IVerifies {
-    verifiable(times?: Times): void;
+    verifiable(times?: Times, expectedCallType?: ExpectedCallType): void;
 }


### PR DESCRIPTION
Per https://github.com/florinn/typemoq/issues/86. This is to match the implementation in MethodCall.ts.